### PR TITLE
BUGFIX: make sure owner label displays when hover over shared workspace icon

### DIFF
--- a/Resources/Private/JavaScript/components/WorkspaceTableRow.tsx
+++ b/Resources/Private/JavaScript/components/WorkspaceTableRow.tsx
@@ -101,7 +101,11 @@ const WorkspaceTableRow: React.FC<WorkspaceTableRowProps> = ({ workspaceName, le
                     workspace.isStale
                         ? translate('badge.isStale', 'This workspace has not been used for a long time')
                         : workspace.acl.length > 0
-                        ? translate('table.column.access.acl')
+                        ? translate(
+                            'table.column.access.acl',
+                            `This workspace is owned by ${workspace.owner.label} but allows access to additional users`,
+                            { owner: workspace.owner.label }
+                          )
                         : workspace.owner
                         ? translate(
                               'table.column.access.private',


### PR DESCRIPTION
## Before
![before](https://user-images.githubusercontent.com/39345336/212692415-804afc9a-ebbe-4414-b403-b170022cf74c.png)

## After
![after](https://user-images.githubusercontent.com/39345336/212692436-bdd392ca-9162-4eb5-b112-dab618b324c8.png)
