### PR TITLE
BUGFIX: Dont crash in cli context

### DIFF
--- a/Classes/Service/WorkspaceActivityService.php
+++ b/Classes/Service/WorkspaceActivityService.php
@@ -78,7 +78,12 @@ class WorkspaceActivityService
 
     public function shutdownObject(): void
     {
-        $currentUser = $this->securityContext->getAccount()->getAccountIdentifier();
+        $account = $this->securityContext->getAccount();
+        if (!$account) {
+            // probably in cli context
+            return;
+        }
+        $currentUser = $account->getAccountIdentifier();
 
         foreach ($this->updatedWorkspaces as $updatedWorkspace) {
             $workspaceDetails = $this->workspaceDetailsRepository->findOneByWorkspace($updatedWorkspace);


### PR DESCRIPTION
```
The security Context cannot be initialized yet.
Please check if it can be initialized with
$securityContext->canBeInitialized() before trying to do so.

  Type: Neos\Flow\Security\Exception
  Code: 1358513802
  File: Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Flow_Securit
        y_Context.php
  Line: 312

```

when having a command to modify the cr this error will be thrown at shutdown